### PR TITLE
Add CD pipeline (Docker Hub & Render deploy)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,35 @@
+name: CD Pipeline               
+
+on:
+  push:
+    branches: [ main ]          
+
+jobs:
+  cd:
+    runs-on: ubuntu-latest
+
+    steps:
+    # 1 check out code
+    - uses: actions/checkout@v4
+
+    # 2 log in to Docker Hub using the two repo secrets
+    - name: Log in to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+    # 3 build the image defined by your Dockerfile and push
+    - name: Build & push image
+      uses: docker/build-push-action@v5
+      with:
+        push: true
+        tags: |
+          ${{ secrets.DOCKERHUB_USERNAME }}/url-shortener:latest
+          ${{ secrets.DOCKERHUB_USERNAME }}/url-shortener:${{ github.sha }}
+
+    # 4 (deploy step will be added once I have Render hook)
+    # - name: Trigger Render deploy
+    #   if: secrets.RENDER_DEPLOY_HOOK != 'PLACEHOLDER'
+    #   run: |
+    #     curl -fsSL -X POST "${{ secrets.RENDER_DEPLOY_HOOK }}"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -2,7 +2,8 @@ name: CD Pipeline
 
 on:
   push:
-    branches: [ main ]          
+    branches: [ main ]    
+  workflow_dispatch: 
 
 jobs:
   cd:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -29,8 +29,7 @@ jobs:
           ${{ secrets.DOCKERHUB_USERNAME }}/url-shortener:latest
           ${{ secrets.DOCKERHUB_USERNAME }}/url-shortener:${{ github.sha }}
 
-    # 4 (deploy step will be added once I have Render hook)
-    # - name: Trigger Render deploy
-    #   if: secrets.RENDER_DEPLOY_HOOK != 'PLACEHOLDER'
-    #   run: |
-    #     curl -fsSL -X POST "${{ secrets.RENDER_DEPLOY_HOOK }}"
+    # 4 deploy step 
+    - name: Trigger Render deploy
+      run: curl -fsSL -X POST "${{ secrets.RENDER_DEPLOY_HOOK }}"
+


### PR DESCRIPTION
This PR merges my CD work into the main repo.
It includes `.github/workflows/cd.yml` – builds the Docker image, pushes to Docker Hub, and triggers a Render deploy using the `RENDER_DEPLOY_HOOK` secret.

**Note for Elior:**  
Before merging, please add these three secrets in `eliorabaev/DevopsFinal → Settings → Secrets`:  
• `DOCKERHUB_USERNAME`  
• `DOCKERHUB_TOKEN` (Read/Write token)  
• `RENDER_DEPLOY_HOOK` (Render’s deploy-hook URL)

Once merged, every push to `main` will automatically rebuild, push, and redeploy the service.

@eliorabaev @AdirGelkop 