### PR TITLE
fix: restore missing Render deploy hook step

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -33,3 +33,6 @@ jobs:
           tags: |
             ${{ secrets.DOCKERHUB_USERNAME }}/url-shortener:latest
             ${{ secrets.DOCKERHUB_USERNAME }}/url-shortener:${{ github.sha }}
+
+      - name: Trigger Render deploy
+        run: curl -fsSL -X POST "${{ secrets.RENDER_DEPLOY_HOOK }}"


### PR DESCRIPTION
- Re-add Trigger Render deploy step that was accidentally removed
- Ensures deployment actually triggers after Docker image build/push
